### PR TITLE
use localStorage for HTML5 builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A module to help you save / load config and player data in your Defold projects 
 You can use DefSave in your own project by adding this project as a [Defold library dependency](http://www.defold.com/manuals/libraries/). Open your game.project file and in the dependencies field under project add:
 
 	https://github.com/subsoap/defsave/archive/master.zip
-  
+
 Once added, you must require the main Lua module in scripts via
 
 ```
@@ -81,22 +81,23 @@ Set verbose to true to also print any successful messages, otherwise only errors
 
 If you need to backup or clear your save data you can find it in:
 
-Windows
+**Windows**
 >%appdata%\Roaming\appname\filename
 
-OS X
+**OS X**
 >~/Library/Application Support/appname/filename
 
-Linux (default path is slightly modified to be within .config user folder)
+**Linux** (default path is slightly modified to be within .config user folder)
 >~/.config/appname/filename
 
-iOS
+**iOS**
 >/var/mobile/Containers/Data/Application/{app-uid?}/Library/Application Support/appname/filename
 
-Android 
+**Android**
 >/data/data/com.packagename/files/filename
 
-HTML5
->/data/.appname/filename
+**HTML5**
+
+Uses [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage), under item named `"appname_filename"`.
 
 The appname is based on the function for getting the path sys.get_save_file("appname", "filename") by default DefSave saves in the OS appropriate location and not next to the binary.

--- a/defsave/defsave.lua
+++ b/defsave/defsave.lua
@@ -1,6 +1,7 @@
 -- DefSave helps with loading and saving config and player data between sesssions
 
 local utf8 = require("defsave.utf8")
+local json = require("defsave.json") -- used for HTML5
 
 local M = {}
 
@@ -35,10 +36,10 @@ function M.obfuscate(input, key)
 	key = key or M.obfuscation_key
 	local output = ""
 	local key_iterator = 1
-	
+
 	local input_length = #input
 	local key_length = #key
-	
+
 	for i=1, input_length do
 		local character = string.byte(input:sub(i,i))
 		if key_iterator >= key_length + 1 then key_iterator = 1 end -- cycle
@@ -46,7 +47,7 @@ function M.obfuscate(input, key)
 		output = output .. string.char(bit.bxor( character , key_byte))
 
 		key_iterator = key_iterator + 1
-		
+
 	end
 	return output
 end
@@ -89,24 +90,28 @@ function M.get_file_path(file)
 		-- For Linux we must modify the default path to make Linux users happy
 		local appname = "config/" .. tostring(M.appname)
 		return sys.get_save_file(appname, file)
-	end
+  end
+  if html5 then
+    -- For HTML5 there's no need to get the full path
+    return M.appname .. "_" .. file
+  end
 	return sys.get_save_file(M.appname, file)
 end
 
 function M.load(file)
 
-	if file == nil then 
+	if file == nil then
 		print("DefSave: Warning no file specified when attempting to load")
 		return nil
 	end
-	
-	local path = M.get_file_path(file)	
-	
+
+	local path = M.get_file_path(file)
+
 	if path == nil then
 		print("DefSave: Warning path returned when attempting to load is nil")
 		return nil
 	end
-	
+
 	if M.loaded[file] ~= nil then
 		if M.block_reloading == false then
 			print("DefSave: Warning the file " .. file .. " was already loaded and will be reloaded possibly overwriting changes")
@@ -114,43 +119,52 @@ function M.load(file)
 			print("DefSave: Warning attempt to reload already file has been blocked")
 			return true
 		end
-	end
-	
-	local loaded_file = sys.load(path)
-	
+  end
+
+  local loaded_file
+  if html5 then
+    -- sys.load can't be used for HTML5 apps running on iframe from a different origin (cross-origin iframe)
+    -- use `localStorage` instead because of this limitation on default IndexedDB storage used by Defold
+    loaded_file = json.decode(html5.run([[
+      window.localStorage.getItem(']] .. path .. [[') || '{}'
+    ]]))
+  else
+    loaded_file  = sys.load(path)
+  end
+
 	local empty = false
-	
-	
+
+
 	if next(loaded_file) == nil then
 		if M.verbose then print("DefSave: Loaded file '" .. file .. "' is empty") end
 		empty = true
 	end
-	
-	if M.use_default_data and empty then 
+
+	if M.use_default_data and empty then
 		if (M.reset_to_default(file)) then
 			return true
 		else
 			return false
 		end
-		
+
 	elseif empty then
 		print("DefSave: The " .. file .. " is loaded but it was empty")
 		M.loaded[file] = {}
 		M.loaded[file].changed = true
 		M.changed = true
 		M.loaded[file].data = {}
-		return true		
+		return true
 	end
-	
+
 
 	M.loaded[file] = {}
 	M.loaded[file].changed = false
 	M.loaded[file].data = loaded_file
-	
+
 	if M.verbose then  print("DefSave: The file '" .. file .. "' was successfully loaded") end
-	
+
 	return true
-	
+
 end
 
 function M.save(file, force)
@@ -160,16 +174,29 @@ function M.save(file, force)
 		print("DefSave: Warning attempt to save a file which could not be found in loaded list")
 		return nil
 	end
-	
+
 	if M.loaded[file].changed == false and force == false then
 		if M.verbose then  print("DefSave: File '" .. file .. "' is unchanged so not saving, set force flag to true to force saving if changed flag is false") end
 		return true
 	end
-	
-	local path = M.get_file_path(file)
-	
-	
-	if sys.save(path, M.loaded[file].data) then
+
+  local path = M.get_file_path(file)
+
+  local is_save_successful;
+  if html5 then
+    -- sys.save can't be used for HTML5 apps running on iframe from a different origin (cross-origin iframe)
+    -- use `localStorage` instead because of this limitation on default IndexedDB storage used by Defold
+    local encoded_data = json.encode(M.loaded[file].data):gsub("'", "\'") -- escape ' characters
+    html5.run([[
+      window.localStorage.setItem(']] .. path .. [[', ']] .. encoded_data .. [[')
+    ]])
+    is_save_successful = true
+
+  else
+    is_save_successful = sys.save(path, M.loaded[file].data)
+  end
+
+	if is_save_successful then
 		if M.verbose then print("DefSave: File '" .. tostring(file) .. "' has been saved to the path '" .. path .. "'") end
 		M.loaded[file].changed = false
 		return true
@@ -184,7 +211,7 @@ function M.save_all(force)
 	force = force or false
 	for key, value in pairs(M.loaded) do
 		M.save(key, force)
-		M.changed = false		
+		M.changed = false
 	end
 end
 
@@ -245,7 +272,7 @@ function M.reset_to_default(file)
 		M.changed = true
 		M.loaded[file].data = {}
 		return true
-	end	
+	end
 end
 
 
@@ -265,8 +292,8 @@ function M.update(dt)
 			print("DefSave: You must pass dt to defsave.update")
 		end
 		M.timer = M.timer + dt
-		
-		
+
+
 		if M.timer >= M.autosave_timer then
 			if M.changed == true then
 				M.save_all()


### PR DESCRIPTION
Fixes https://forum.defold.com/t/html5-save-user-progress-inside-an-iframe/64073

**How to reproduce the issue:**
- Use DefSave from `http://localhost:8000`
- Have an iframe from `http://localhost:8001` pointing to `http://localhost:8000`
- Open `http://localhost:8001` on Safari (or Mobile Safari)

By following the steps described above, you'll observe that only a `SecurityError` will appear in the developer tool's console, and the data is not going to be stored.
